### PR TITLE
Typo in Type

### DIFF
--- a/src/posts/whats-in-a-fold.md
+++ b/src/posts/whats-in-a-fold.md
@@ -261,7 +261,7 @@ a b`.
 
 ``` haskell
 -- A simple demonstration of foldList in action.
-f :: ListF a b -> b
+f :: Num a => ListF a a -> a
 f = \case { Nil -> 0; Cons x y -> x + y }
 
 foldList f [1, 2, 3]


### PR DESCRIPTION
Or simply use:
```haskell
f :: ListF Int Int -> Int
```